### PR TITLE
Implemented the app for slicing text given start and end time

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Use the same base image version as the clams-python python library version
-FROM ghcr.io/clamsproject/clams-python:1.2.3
+FROM ghcr.io/clamsproject/clams-python:1.2.5
 # See https://github.com/orgs/clamsproject/packages?tab=packages&q=clams-python for more base images
 # IF you want to automatically publish this image to the clamsproject organization,
 # 1. you should have generated this template without --no-github-actions flag
@@ -25,7 +25,7 @@ ENV HF_HOME="/cache/huggingface"
 # https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved
 ENV TORCH_HOME="/cache/torch"
 
-RUN mkdir /cache && rm -rf /root/.cache && ln -s /cache /root/.cache
+RUN mkdir /cache ; rm -rf /root/.cache ; ln -s /cache /root/.cache
 ################################################################################
 
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -1,66 +1,44 @@
-# TO_DEVS: BURN AFTER READING
-
-Delete this section of the document once the app development is done, before publishing the repository.
-
----
-This skeleton code is a scaffolding for Python-based CLAMS app development. Specifically, it contains
-
-1. `app.py` and `metadata.py` to write the app
-1. `requirements.txt` to specify python dependencies
-1. `Containerfile` to containerize the app and specify system dependencies
-1. `.gitignore` and `.dockerignore` files listing commonly ignored files
-1. an empty `LICENSE` file to replace with an actual license information of the app
-1. This `README.md` file for additional information not specified in the general user manual at https://apps.clams.ai/clamsapp
-1. A number of GitHub Actions workflows for issue/bugreport management
-1. A GHA workflow to publish app images upon any push of a git tag
-   * **NOTE**: All GHA workflows included are designed to only work in repositories under `clamsproject` organization.
-
-Before pushing your first commit, please make sure to delete this section of the document.
-
-Then use the following section to document any additional information specific to this app. If your app works significantly different from what's described in the generic readme file, be as specific as possible.
-
-
-> **warning**
-> TO_DEVS: Delete these `TO_DEVS` notes and warnings before publishing the repository.
-
----
-
 # Text Slicer
 
-> **warning**
-> TO_DEVS: Again, delete these `TO_DEVS` notes and warnings before publishing the repository.
-
 ## Description
-
-> **note**
-> TO_DEVS: A brief description of the app, expected behavior, underlying software/library/technology, etc.
+The app named `app-text-slicer` is used to "slice" (or extract) snippets of text from
+given single `TextDocument` based on single or multiple `TimeFrame` annotations within the `Mmif` object.
 
 ## User instruction
+_**Important**_: 
+Users need to read [CLAMS Apps User Manual](https://apps.clams.ai/clamsapp) before using this app.
 
-General user instructions for CLAMS apps are available at [CLAMS Apps documentation](https://apps.clams.ai/clamsapp).
+### Run the app on local server
+To run the app in a containerized environment: 
 
-Below is a list of additional information specific to this app.
+`curl -X ... localhost:<port>?containLabel=<label_X>&containLabel=<label_Y>?<other_params>`
 
-> **note**
-> TO_DEVS: Below is a list of additional information specific to this app.
+### Run the app in CLI
+First, to seek for help from the app, type `python cli.py -h` under the app source directory
 
+Then, similar to other CLAMS apps, to run the app via CLI, do
 
-### System requirements
-
-> **note**
-> TO_DEVS: Any system-level software required to run this app. Usually include some of the following:
-> * supported OS and CPU architectures
-> * usage of GPU
-> * system package names (e.g. `ffmpeg`, `libav`, `libopencv-dev`, etc.)
-> * some example code snippet to install them on Debian/Ubuntu (because our base images are based on Debian)
->     * e.g. `apt-get update && apt-get install -y <package-name>`
+```
+python cli.py \
+    --containLabel=<label_X> \
+    --containLabel=<label_Y> \
+    --other_params \
+    <input_mmif_file_path> \
+    <output_mmif_file_path> 
+```
 
 ### Configurable runtime parameter
 
+`--containLabel`: the parameter to slice texts within `TimeFrame`s having label(s) user provides
+
+
 For the full list of parameters, please refer to the app metadata from the [CLAMS App Directory](https://apps.clams.ai) or the [`metadata.py`](metadata.py) file in this repository.
 
-> **warning**
-> TO_DEVS: If you're not developing this app for publishing on the CLAMS App Directory, the above paragraph is not applicable. Feel free to delete or change it.
+## System requirements
 
-> **note**
-> TO_DEVS: all runtime parameters are supported to be VERY METICULOUSLY documented in the app's `metadata.py` file. However for some reason, if you need to use this space to elaborate what's already documented in `metadata.py`, feel free to do so.
+_**Until 7/1/2024**_:
+```
+clams-python=1.2.5
+```
+
+

--- a/app.py
+++ b/app.py
@@ -39,15 +39,16 @@ class TextSlicer(ClamsApp):
         self.mmif = mmif if isinstance(mmif, Mmif) else Mmif(mmif)
         self.text_doc = self.mmif.get_documents_by_type(DocumentTypes.TextDocument)
         assert len(self.text_doc) == 1, "There should be exactly one TextDocument in the MMIF file"
+        label_set = set(parameters["containLabel"])
+        assert len(label_set) >= 1, "There should be at least one label in the parameters"  # Here we make the label parameter as required
 
-        label_set = set(parameters["containLabels"])
         new_view = self.mmif.new_view()
         self.sign_view(new_view, parameters)
 
         for tf_view in self.mmif.get_all_views_contain(AnnotationTypes.TimeFrame):
             tf_anns_in_view = tf_view.get_annotations(AnnotationTypes.TimeFrame)
             for tf_ann in tf_anns_in_view:
-                if not label_set or tf_ann.get_property('label') in label_set:
+                if tf_ann.get_property('label') in label_set:
                     start_time = self.mmif.get_start(tf_ann) 
                     end_time = self.mmif.get_end(tf_ann) 
                     sliced_text = new_view.new_textdocument(text_document_helper.slice_text(self.mmif, start_time, end_time))
@@ -55,6 +56,7 @@ class TextSlicer(ClamsApp):
                                                         properties={'source': tf_ann.long_id, 'target': sliced_text.long_id}) 
 
         return self.mmif
+
 
 def get_app():
     """

--- a/app.py
+++ b/app.py
@@ -39,9 +39,8 @@ class TextSlicer(ClamsApp):
         self.mmif = mmif if isinstance(mmif, Mmif) else Mmif(mmif)
         self.text_doc = self.mmif.get_documents_by_type(DocumentTypes.TextDocument)
         assert len(self.text_doc) == 1, "There should be exactly one TextDocument in the MMIF file"
-        label_set = set(parameters["containLabel"])
-        assert len(label_set) >= 1, "There should be at least one label in the parameters"  # Here we make the label parameter as required
 
+        label_set = set(parameters["containLabel"])
         new_view = self.mmif.new_view()
         self.sign_view(new_view, parameters)
 

--- a/app.py
+++ b/app.py
@@ -40,21 +40,19 @@ class TextSlicer(ClamsApp):
         self.text_doc = self.mmif.get_documents_by_type(DocumentTypes.TextDocument)
         assert len(self.text_doc) == 1, "There should be exactly one TextDocument in the MMIF file"
 
-        labels = parameters["contain_labels"]
-        label_set = set([label.strip() for label in labels.split(',')] if labels else [])
-
+        label_set = set(parameters["containLabels"])
         new_view = self.mmif.new_view()
         self.sign_view(new_view, parameters)
 
         for tf_view in self.mmif.get_all_views_contain(AnnotationTypes.TimeFrame):
             tf_anns_in_view = tf_view.get_annotations(AnnotationTypes.TimeFrame)
             for tf_ann in tf_anns_in_view:
-                if not label_set or tf_ann._get_label() in label_set:
+                if not label_set or tf_ann.get_property('label') in label_set:
                     start_time = self.mmif.get_start(tf_ann) 
                     end_time = self.mmif.get_end(tf_ann) 
                     sliced_text = new_view.new_textdocument(text_document_helper.slice_text(self.mmif, start_time, end_time))
                     new_align = new_view.new_annotation(at_type=AnnotationTypes.Alignment,
-                                                        properties={'source': tf_ann.id, 'target': sliced_text.id}) 
+                                                        properties={'source': tf_ann.long_id, 'target': sliced_text.long_id}) 
 
         return self.mmif
 

--- a/metadata.py
+++ b/metadata.py
@@ -47,19 +47,15 @@ def appmetadata() -> AppMetadata:
     
     # (optional) and finally add runtime parameter specifications
     metadata.add_parameter(name='containLabel',
-                           description=
-                           '''
-                           A list of labels that user expect TimeFrames contain.
-                           Available options are:
-                           ['bars', 'tones', 'bars-and-tones','speech',
-                           'noise', 'music', 'slate', 'chyron',
-                           'lower-third', 'credits']
-                           Users must select at least one of the following labels, errors would 
-                           be thrown instead.
-                           ''',
+                           description="A list of labels that user expect TimeFrames contain.\n"
+                                       "Labels can be chosen from but not limited to:\n"
+                                       "['bars', 'tones', 'bars-and-tones','speech','noise',\n "
+                                       "'music', 'slate', 'chyron', 'lower-third', 'credits']\n"
+                                       "Users are required to select at least one label. Otherwise, "
+                                       "errors would be thrown instead",
                            type='string',
                            multivalued=True,  # Allow users to input one or more labels wanted
-                           default=[])
+                           )
     return metadata
 
 

--- a/metadata.py
+++ b/metadata.py
@@ -47,11 +47,20 @@ def appmetadata() -> AppMetadata:
     
     
     # (optional) and finally add runtime parameter specifications
-    # metadata.add_parameter(name='start_time', description='start time of the slice', type='number', default='0')
-    # metadata.add_parameter(name='end_time', description='end time of the slice', type='number', default='10000')
-    # metadata.add_parameter(name='unit', description='unit of the time', type='string', default='ms')
-    
-    # CHANGE this line and make sure return the compiled `metadata` instance
+    metadata.add_parameter(name='contain_labels',
+                           description=
+                           '''
+                           A list of labels of TimeFrame to look for.
+                           Available options are:
+                           ['bars', 'tones', 'bars-and-tones','speech',
+                           'noise', 'music', 'slate', 'chyron',
+                           'lower-third', 'credits']
+                           User needs to provide a string of comma-separated labels, 
+                           e.g. 'bars, credits, chyron'.
+                           Default is all are selected.
+                           ''',
+                           type='string',
+                           default='')
     return metadata
 
 

--- a/metadata.py
+++ b/metadata.py
@@ -24,10 +24,10 @@ def appmetadata() -> AppMetadata:
     # first set up some basic information
     metadata = AppMetadata(
         name="Text Slicer",
-        description="slice text snippets",  # briefly describe what the purpose and features of the app
+        description="Slice text snippets",  # briefly describe what the purpose and features of the app
         app_license="Apache2",  # short name for a software license like MIT, Apache2, GPL, etc.
         identifier="text-slicer",  # should be a single string without whitespaces. If you don't intent to publish this app to the CLAMS app-directory, please use a full IRI format.
-        url="https://fakegithub.com/some/repository",  # a website where the source code and full documentation of the app is hosted
+        url="https://github.com/clamsproject/app-text-slicer",  # a website where the source code and full documentation of the app is hosted
         # (if you are on the CLAMS team, this MUST be "https://github.com/clamsproject/app-text-slicer"
         # (see ``.github/README.md`` file in this directory for the reason)
         # analyzer_version='version_X', # use this IF THIS APP IS A WRAPPER of an existing computational analysis algorithm
@@ -44,9 +44,9 @@ def appmetadata() -> AppMetadata:
     metadata.add_output(DocumentTypes.TextDocument)
     
     # (optional) and finally add runtime parameter specifications
-    metadata.add_parameter(name='a_param', description='example parameter description',
-                           type='boolean', default='false')
-    # metadta.add_parameter(more...)
+    metadata.add_parameter(name='start_time', description='start time of the slice', type='number', default='0')
+    metadata.add_parameter(name='end_time', description='end time of the slice', type='number', default='10000')
+    metadata.add_parameter(name='unit', description='unit of the time', type='string', default='ms')
     
     # CHANGE this line and make sure return the compiled `metadata` instance
     return metadata

--- a/metadata.py
+++ b/metadata.py
@@ -24,7 +24,7 @@ def appmetadata() -> AppMetadata:
     # first set up some basic information
     metadata = AppMetadata(
         name="Text Slicer",
-        description="Slice text snippets",  # briefly describe what the purpose and features of the app
+        description="Slice text snippets from a provided text document given time frames",  # briefly describe what the purpose and features of the app
         app_license="Apache2",  # short name for a software license like MIT, Apache2, GPL, etc.
         identifier="text-slicer",  # should be a single string without whitespaces. If you don't intent to publish this app to the CLAMS app-directory, please use a full IRI format.
         url="https://github.com/clamsproject/app-text-slicer",  # a website where the source code and full documentation of the app is hosted
@@ -40,13 +40,16 @@ def appmetadata() -> AppMetadata:
         # analyzer_license="",  # short name for a software license
     )
     # and then add I/O specifications: an app must have at least one input and one output
-    metadata.add_input(AnnotationTypes.TimeFrame)
+    metadata.add_input(AnnotationTypes.TimeFrame)  # Output from SWT
+    metadata.add_input(DocumentTypes.TextDocument) # Output from OCR
     metadata.add_output(DocumentTypes.TextDocument)
+    metadata.add_output(AnnotationTypes.Alignment)
+    
     
     # (optional) and finally add runtime parameter specifications
-    metadata.add_parameter(name='start_time', description='start time of the slice', type='number', default='0')
-    metadata.add_parameter(name='end_time', description='end time of the slice', type='number', default='10000')
-    metadata.add_parameter(name='unit', description='unit of the time', type='string', default='ms')
+    # metadata.add_parameter(name='start_time', description='start time of the slice', type='number', default='0')
+    # metadata.add_parameter(name='end_time', description='end time of the slice', type='number', default='10000')
+    # metadata.add_parameter(name='unit', description='unit of the time', type='string', default='ms')
     
     # CHANGE this line and make sure return the compiled `metadata` instance
     return metadata

--- a/metadata.py
+++ b/metadata.py
@@ -40,27 +40,27 @@ def appmetadata() -> AppMetadata:
         # analyzer_license="",  # short name for a software license
     )
     # and then add I/O specifications: an app must have at least one input and one output
-    metadata.add_input(AnnotationTypes.TimeFrame)  # Output from SWT
-    metadata.add_input(DocumentTypes.TextDocument) # Output from OCR
+    metadata.add_input(AnnotationTypes.TimeFrame)   # Output from SWT
+    metadata.add_input(DocumentTypes.TextDocument)  # Output from OCR
     metadata.add_output(DocumentTypes.TextDocument)
     metadata.add_output(AnnotationTypes.Alignment)
     
-    
     # (optional) and finally add runtime parameter specifications
-    metadata.add_parameter(name='contain_labels',
+    metadata.add_parameter(name='containLabels',
                            description=
                            '''
-                           A list of labels of TimeFrame to look for.
+                           A list of labels that user expect TimeFrames contain.
                            Available options are:
                            ['bars', 'tones', 'bars-and-tones','speech',
                            'noise', 'music', 'slate', 'chyron',
                            'lower-third', 'credits']
-                           User needs to provide a string of comma-separated labels, 
-                           e.g. 'bars, credits, chyron'.
-                           Default is all are selected.
+                           User needs to provide a list of labels if multiple labels are expected
+                           e.g. ['bars', 'credits', 'chyron'].
+                           Default value is all labels are selected.
                            ''',
                            type='string',
-                           default='')
+                           multivalued=True,  # Allow users to input one or more labels wanted
+                           default=[])
     return metadata
 
 

--- a/metadata.py
+++ b/metadata.py
@@ -46,7 +46,7 @@ def appmetadata() -> AppMetadata:
     metadata.add_output(AnnotationTypes.Alignment)
     
     # (optional) and finally add runtime parameter specifications
-    metadata.add_parameter(name='containLabels',
+    metadata.add_parameter(name='containLabel',
                            description=
                            '''
                            A list of labels that user expect TimeFrames contain.
@@ -54,9 +54,8 @@ def appmetadata() -> AppMetadata:
                            ['bars', 'tones', 'bars-and-tones','speech',
                            'noise', 'music', 'slate', 'chyron',
                            'lower-third', 'credits']
-                           User needs to provide a list of labels if multiple labels are expected
-                           e.g. ['bars', 'credits', 'chyron'].
-                           Default value is all labels are selected.
+                           Users must select at least one of the following labels, errors would 
+                           be thrown instead.
                            ''',
                            type='string',
                            multivalued=True,  # Allow users to input one or more labels wanted

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Make sure clams-python version is explicitly specified, at least the lower bound
-clams-python==1.2.4
+clams-python==1.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Make sure clams-python version is explicitly specified, at least the lower bound
-clams-python==1.2.3
+clams-python==1.2.4


### PR DESCRIPTION
## Implementations

1. Changed the version of clams from 1.2.3 to 1.2.4
2. Added user/client input parameters for the app
3. Implemented necessary functions: `_metadata` and `_annotate`

## Results

The sliced text results are tested via:

1. Verify if additional `view` is added into the input `.mmif` file
2. Compare the sliced text is the same as the one returned by `text_document_helper.slice_text` of `clams-python=1.2.4`

## Questions

- Should the `TextDocument` be one of the inputs in app's metadata rather than only `TimeFrame` (while using `add_input` function)? 